### PR TITLE
Support for multiple options passed to diff

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -29,9 +29,8 @@ module Diffy
           when 'files'
             [string1, string2]
           end
-        diff ||= Open3.popen3(
-          *[ diff_bin, options[:diff], *paths ]
-        ) { |i, o, e| o.read }
+        diff_opts = options[:diff].is_a?(Array) ? options[:diff] : [options[:diff]]
+        diff = Open3.popen3(diff_bin, *diff_opts, *paths) { |i, o, e| o.read }
         if diff =~ /\A\s*\Z/
           diff = case options[:source]
           when 'strings' then string1

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -39,6 +39,25 @@ describe Diffy::Diff do
     end
   end
 
+  describe "options[:diff]" do
+    it "should accept an option to diff" do
+      @diff = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :diff => "-w")
+      @diff.to_s.should == <<-DIFF
+  foo
+ bar
+      DIFF
+    end
+
+    it "should accept multiple arguments to diff" do
+      @diff = Diffy::Diff.new(" foo\nbar\n", "foo\nbaz\n", :diff => ["-w", "-U 3"])
+      @diff.to_s.should == <<-DIFF
+  foo
+-bar
++baz
+      DIFF
+    end
+  end
+
   describe "#to_s" do
     describe "with no line different" do
       before do


### PR DESCRIPTION
I ran into an issue where the diff was breaking when multiple options were passed into diff (and then into Open3). It seems that the options need to be passed in as separate parameters. Tests are also included.
