### PR TITLE
Fix for Issue #3

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -19,8 +19,8 @@ module Diffy
         raise ArgumentError, "Invalid :source option #{@options[:source].inspect}. Supported options are 'strings' and 'files'."
       end
 	  # Having \\ on a line freaks out the diff utility, not an elegant fix but it does work
-	  string1.gsub "\\", ""
-	  string2.gsub "\\", ""
+	  string1 = string1.gsub "\\", ""
+	  string2 = string2.gsub "\\", ""
       @string1, @string2 = string1, string2
     end
 


### PR DESCRIPTION
It is not exactly a flawless fix, because we now lose information on \, however, it is the lesser of the two evil since it doesn't leave out entire lines of text just because there's \ on one line.
