### PR TITLE
hide possible STDERR output

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -117,10 +117,12 @@ module Diffy
     private
 
     def diff_bin
+      @@dev_null_path ||= ["/dev/null", "/NUL"].select{|p| File.exists?(p)}.first
+
       @@bin ||=""
       
-      @@bin = `which diff.exe`.chomp if @@bin.empty?
-      @@bin = `which diff`.chomp if @@bin.empty?
+      @@bin = `which diff.exe 2>#{@@dev_null_path}`.chomp if @@bin.empty?
+      @@bin = `which diff 2>#{@@dev_null_path}`.chomp if @@bin.empty?
 
       if @@bin.empty?
         raise "Can't find a diff executable in PATH #{ENV['PATH']}"


### PR DESCRIPTION
`which diff.exe` is guaranteed to fail on linux, producing message like this:

<pre>
which: no diff.exe in (/home1/s/siyusong/.rvm/gems/ruby-1.9.3-p194/bin:/home1/s/siyusong/.rvm/gems/ruby-1.9.3-p194@global/bin:/home1/s/siyusong/.rvm/rubies/ruby-1.9.3-p194/bin:/home1/s/siyusong/.rvm/bin:/usr/local/ghc-7.0.4/bin/:/usr/lib64/mpi/gcc/openmpi/bin:/home1/s/siyusong/bin:/usr/local/bin:/usr/bin:/bin:/usr/bin/X11:/usr/X11R6/bin:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin:/usr/lib/qt3/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/opt/kde3/bin:/opt/gnome/bin:/home1/s/siyusong/bin:/home1/s/siyusong/.cabal/bin:/home1/s/siyusong/.rvm/bin:/home1/s/siyusong/.rvm/usr:/home1/s/siyusong/subl:/home1/s/siyusong/android-sdk-linux/platform-tools:/home1/s/siyusong/android-sdk-linux/tools:.:/home1/s/siyusong/.opt/bin)
</pre>


Hiding the STDERR output could make the output tidier.
