### PR TITLE
Added :hide_unchanged_lines option to hide unchanged lines in diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swp
 Gemfile.lock
 tags
+.rvmrc
+.idea

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -13,7 +13,8 @@ module Diffy
           :diff => '-U 10000',
           :source => 'strings',
           :include_diff_info => false,
-          :include_plus_and_minus_in_html => false
+          :include_plus_and_minus_in_html => false,
+          :hide_unchanged_lines => false
         }
       end
 
@@ -118,7 +119,7 @@ module Diffy
 
     def diff_bin
       @@bin ||=""
-      
+
       @@bin = `which diff.exe`.chomp if @@bin.empty?
       @@bin = `which diff`.chomp if @@bin.empty?
 

--- a/lib/diffy/format.rb
+++ b/lib/diffy/format.rb
@@ -3,7 +3,7 @@ module Diffy
     # ANSI color output suitable for terminal output
     def color
       map do |line|
-        case line          
+        case line
         when /^(---|\+\+\+|\\\\)/
           "\033[90m#{line.chomp}\033[0m"
         when /^\+/
@@ -13,14 +13,16 @@ module Diffy
         when /^@@/
           "\033[36m#{line.chomp}\033[0m"
         else
-          line.chomp
+          line.chomp unless @options[:hide_unchanged_lines]
         end
-      end.join("\n") + "\n"
+      end.compact.join("\n") + "\n"
     end
 
     # Basic text output
     def text
-      to_a.join
+      map do |line|
+        line unless line =~ /^ / && @options[:hide_unchanged_lines]
+      end.compact.join
     end
 
     # Basic html output which does not attempt to highlight the changes

--- a/lib/diffy/html_formatter.rb
+++ b/lib/diffy/html_formatter.rb
@@ -24,7 +24,7 @@ module Diffy
       when /^-/
         '    <li class="del"><del>' + cleaned + '</del></li>'
       when /^ /
-        '    <li class="unchanged"><span>' + cleaned + '</span></li>'
+        '    <li class="unchanged"><span>' + cleaned + '</span></li>' unless @options[:hide_unchanged_lines]
       when /^@@/
         '    <li class="diff-block-info"><span>' + line.chomp + '</span></li>'
       end
@@ -40,7 +40,7 @@ module Diffy
     end
 
     def wrap_lines(lines)
-      %'<div class="diff">\n  <ul>\n#{lines.join("\n")}\n  </ul>\n</div>\n'
+      %'<div class="diff">\n  <ul>\n#{lines.compact.join("\n")}\n  </ul>\n</div>\n'
     end
 
     def highlighted_words

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -124,6 +124,56 @@ describe Diffy::Diff do
 
   end
 
+  describe "options[:hide_unchanged_lines]" do
+    it "defaults to false" do
+      @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n")
+      @diffy.options[:hide_unchanged_lines].should == false
+    end
+
+    it "can be set to true" do
+      @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :hide_unchanged_lines=> true )
+      @diffy.options[:hide_unchanged_lines].should == true
+    end
+
+    describe "formats" do
+      it "hide lines in html_simple" do
+        output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :hide_unchanged_lines => true ).
+          to_s(:html_simple)
+        output.should == <<-HTML
+<div class="diff">
+  <ul>
+    <li class="del"><del>bar</del></li>
+  </ul>
+</div>
+        HTML
+      end
+
+      it "hide lines in html" do
+        output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\naba\nbang\n", :hide_unchanged_lines => true ).
+          to_s(:html)
+        output.should == <<-HTML
+<div class="diff">
+  <ul>
+    <li class="del"><del>ba<strong>r</strong></del></li>
+    <li class="ins"><ins><strong>a</strong>ba</ins></li>
+  </ul>
+</div>
+        HTML
+      end
+
+      it 'hide lines in color' do
+        output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :hide_unchanged_lines => true ).to_s(:color)
+        output.should == "\033[31m-bar\033[0m\n"
+      end
+
+      it 'hide lines in text' do
+        output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :hide_unchanged_lines => true ).to_s(:text)
+        output.should == "-bar\n"
+      end
+    end
+
+  end
+
   describe "options[:include_diff_info]" do
     it "defaults to false" do
       @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n")


### PR DESCRIPTION
Hey guys, 

I have to check many files and do a general report what was changed. Sometimes files are very long and don't have any changes or have a little. With adding an option :hide_unchanged_lines I can filter only changed lines to make a report short and usefull. What do you think?
