### PR TITLE
Change Enumerator.new to Object#to_enum

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -86,7 +86,7 @@ module Diffy
       if block_given?
         chunks.each{|chunk| yield chunk }
       else
-        Enumerable::Enumerator.new(chunks)
+        chunks.to_enum
       end
     end
 


### PR DESCRIPTION
 Enumerator.new without a block is deprecated in Ruby 2.0.

```
$ irb
2.0.0dev :001 > Enumerator.new('a')
(irb):1: warning: Enumerator.new without a block is deprecated; use Object#to_enum
 => #<Enumerator: "a":each> 
```
