### PR TITLE
Windows needs quoted paths to handle paths with spaces. 

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -48,7 +48,7 @@ module Diffy
 
         if WINDOWS
           # don't use open3 on windows
-          cmd = "#{diff_bin} #{diff_options.join(' ')} #{paths.join(' ')}"
+          cmd = "\"#{diff_bin}\" #{diff_options.join(' ')} #{paths.join(' ')}"
           diff = `#{cmd}`
         else
           diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }


### PR DESCRIPTION
The default location for Diff is C:\Program Files(x86)... which includes a space.
