### PR TITLE
allow_empty_diff default to true

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+allow_empty_diff is true by default
+
 == 2.1.0 ==
 Windows support
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ And even deals a bit with the formatting!
 
 ### Empty Diff Behavior
 
-By default diffy will return the full text of its first input if there are no
-differences with the second input.  Sometimes it's useful to return the actual
-diff, the empty string, in this case.  To enable this behavior, simply use the
-`:allow_empty_diff => true` option when initializing.
+By default diffy will return empty string if there are no
+differences in inputs. In previous versions the full text of its first input
+was returned in this case. To restore this behaviour simply use the
+`:allow_empty_diff => false` option when initializing.
 
 ### Plus and Minus symbols in HTML output
 

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -14,7 +14,8 @@ module Diffy
           :source => 'strings',
           :include_diff_info => false,
           :include_plus_and_minus_in_html => false,
-          :context => nil
+          :context => nil,
+          :allow_empty_diff => true,
         }
       end
 

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -35,7 +35,8 @@ describe Diffy::Diff do
       end
 
       it "should show everything" do
-        Diffy::Diff.new(@path1, @path2, :source => 'files').to_s.should == <<-DIFF
+        Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => false).
+          to_s.should == <<-DIFF
  foo
  bar
  bang
@@ -173,7 +174,7 @@ describe Diffy::Diff do
 
   describe "options[:diff]" do
     it "should accept an option to diff" do
-      @diff = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :diff => "-w")
+      @diff = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :diff => "-w", :allow_empty_diff => false)
       @diff.to_s.should == <<-DIFF
   foo
  bar
@@ -198,7 +199,7 @@ describe Diffy::Diff do
       end
 
       it "should show everything" do
-        Diffy::Diff.new(@string1, @string2).to_s.should == <<-DIFF
+        Diffy::Diff.new(@string1, @string2, :allow_empty_diff => false).to_s.should == <<-DIFF
  foo
  bar
  bang


### PR DESCRIPTION
Maybe it would be better to make `allow_empty_diff` default to `true`. It's more expected.
