### PR TITLE
Fixing diff-comments and close by empty diff

### DIFF
--- a/lib/diffy/html_formatter.rb
+++ b/lib/diffy/html_formatter.rb
@@ -40,7 +40,11 @@ module Diffy
     end
 
     def wrap_lines(lines)
-      %'<div class="diff">\n  <ul>\n#{lines.join("\n")}\n  </ul>\n</div>\n'
+      if lines.empty?
+        %'<div class="diff"/>'
+      else
+        %'<div class="diff">\n  <ul>\n#{lines.join("\n")}\n  </ul>\n</div>\n'
+      end
     end
 
     def highlighted_words
@@ -61,14 +65,19 @@ module Diffy
         dir2 = chunk2.each_char.first
         case [dir1, dir2]
         when ['-', '+']
-          line_diff = Diffy::Diff.new(
-            split_characters(chunk1),
-            split_characters(chunk2)
-          )
-          hi1 = reconstruct_characters(line_diff, '-')
-          hi2 = reconstruct_characters(line_diff, '+')
-          processed << (index + 1)
-          [hi1, hi2]
+          if chunk1.each_char.take(3).join("") =~ /^(---|\+\+\+|\\\\)/ and
+              chunk2.each_char.take(3).join("") =~ /^(---|\+\+\+|\\\\)/
+            ERB::Util.h(chunk1)
+          else
+            line_diff = Diffy::Diff.new(
+                                        split_characters(chunk1),
+                                        split_characters(chunk2)
+                                        )
+            hi1 = reconstruct_characters(line_diff, '-')
+            hi2 = reconstruct_characters(line_diff, '+')
+            processed << (index + 1)
+            [hi1, hi2]
+          end
         else
           ERB::Util.h(chunk1)
         end


### PR DESCRIPTION
Fixing bug for diff-comments by html formatter:
it was:

``` html
<li class="del"><del><strong>--</strong> /tmp/diffy20130605-4371-<strong>kywx0v</strong>-0  2013-06-05 13:58:53.000000000 +0200</del></li>
<li class="ins"><ins><strong>++</strong> /tmp/diffy20130605-4371-<strong>1arvip</strong>-0  2013-06-05 13:58:53.000000000 +0200</ins></li>
```

adding row to close <div class="diff"/> directly if the diff is empty -> allow-empty-diff. Better xhtml and better for parsing.
