### PR TITLE
Added Diff3 Support

### DIFF
--- a/diffy.gemspec
+++ b/diffy.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "diffy"
-  s.version = "3.0.1"
+  s.version = "3.1.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Sam Goldstein"]
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
     "lib/diffy.rb",
     "lib/diffy/css.rb",
     "lib/diffy/diff.rb",
+    "lib/diffy/diff3.rb",
     "lib/diffy/format.rb",
     "lib/diffy/html_formatter.rb",
     "spec/demo_app.rb",

--- a/lib/diffy.rb
+++ b/lib/diffy.rb
@@ -9,4 +9,5 @@ require 'open3' unless Diffy::WINDOWS
 require File.join(File.dirname(__FILE__), 'diffy', 'format')
 require File.join(File.dirname(__FILE__), 'diffy', 'html_formatter')
 require File.join(File.dirname(__FILE__), 'diffy', 'diff')
+require File.join(File.dirname(__FILE__), 'diffy', 'diff3')
 require File.join(File.dirname(__FILE__), 'diffy', 'css')

--- a/lib/diffy/diff3.rb
+++ b/lib/diffy/diff3.rb
@@ -178,7 +178,7 @@ module Diffy
 
     # attempts to update mine to include newly added, non-conflicted changes from yours
     def patched_mine
-      @rebased_mine ||= begin
+      @patched_mine ||= begin
         lines = []
         change_groups.each do |group|
           lines += group.patched_mine

--- a/lib/diffy/diff3.rb
+++ b/lib/diffy/diff3.rb
@@ -1,0 +1,210 @@
+module Diffy
+  class Diff3 < Diffy::Diff
+    class << self
+      attr_writer :default_format
+      def default_format
+        @default_format || :text
+      end
+
+      attr_writer :default_options
+      # default options passed to new Diff objects
+      def default_options
+        @default_options ||= {
+            :diff3 => ['-m', '-L older', '-L mine', '-L yours'],
+            :line_merge => true # tries to intelligently merge three way conflicts using line by line comparisons
+        }
+      end
+
+      def diff_bin
+        @bin ||= begin
+          if WINDOWS
+            bin = `which diff3.exe`.chomp
+          else
+            bin = `which diff3`.chomp
+          end
+
+          raise "Can't find a diff3 executable in PATH #{ENV['PATH']}" if bin.empty?
+          bin
+        end
+      end
+    end
+
+    attr_reader :string3
+
+    def initialize(string1, string2, string3, options = {})
+      @options = Diffy::Diff.default_options.merge(self.class.default_options.merge(options))
+      if ! ['strings', 'files'].include?(@options[:source])
+        raise ArgumentError, "Invalid :source option #{@options[:source].inspect}. Supported options are 'strings' and 'files'."
+      end
+
+      @string1, @string2, @string3 = ensure_line_breaks(string1, string2, string3)
+    end
+
+    def older
+      string1
+    end
+
+    def yours
+      string2
+    end
+
+    def mine
+      string3
+    end
+
+    def diff3
+      @diff3 ||= begin
+        paths = case options[:source]
+                  when 'strings'
+                    [tempfile(older), tempfile(yours), tempfile(mine)]
+                  when 'files'
+                    [string1, string2, string3]
+                end
+
+        exec(paths)
+      end
+    end
+
+    def three_way_conflicts?
+      change_groups.any? {|g| g.three_way_conflict?}
+    end
+
+    def conflicts?
+      change_groups.any? {|g| g.conflicts?}
+    end
+
+    def change_groups
+      @change_groups ||= begin
+        groups = []
+        current = nil
+
+        diff3.lines.each do |line|
+          if line.start_with?('<<<<<<<')
+            if current
+              current.close
+              groups << current
+            end
+            current = ChangeGroup.new(self)
+            current.add_line(line)
+          elsif current and current.open?
+            current.add_line(line)
+          else
+            groups << current if current
+            current = ChangeGroup.new(self)
+            current.add_line(line)
+          end
+        end
+
+        if current
+          current.close
+          groups << current
+        end
+
+        groups
+      end
+    end
+
+    class ChangeGroup
+
+      attr_reader :older, :mine, :yours
+
+      def initialize(diff)
+        @diff = diff
+        @open = true
+        @older = []
+        @yours = []
+        @mine = []
+        @target = @older
+        @three_way_conflict = false
+      end
+
+      def conflicts?
+        @yours.any? or @mine.any?
+      end
+
+      def open?
+        @open
+      end
+
+      def close
+        @open = false
+      end
+
+      def three_way_conflict?
+        @three_way_conflict
+      end
+
+      def add_line(line)
+        if line.start_with?('<<<<<<<')
+          if line.include?('older')
+            @three_way_conflict = true
+          else
+            @target = @yours
+          end
+        elsif line.start_with?('|||||||')
+          @target = @yours
+        elsif line.start_with?('=======')
+          @target = @mine
+        elsif line.start_with?('>>>>>>>')
+          @open = false
+          # if there was a 2 way conflict than the older will always be the same content as mine
+          @older = @mine unless @three_way_conflict
+        else
+          @target << line
+        end
+      end
+
+      def patched_mine
+        if conflicts?
+          if mine.any? and mine != older
+            # only try our own line per line merge strategy if the line counts are the same.
+            if @diff.options[:line_merge] and mine.length == older.length
+              lines = []
+              mine.each_with_index do |line, index|
+                lines << (older[index] == line ? yours[index] : line)
+              end
+              lines
+            else
+              mine
+            end
+          else
+            yours
+          end
+        else
+          older
+        end
+      end
+    end
+
+    # attempts to update mine to include newly added, non-conflicted changes from yours
+    def patched_mine
+      @rebased_mine ||= begin
+        lines = []
+        change_groups.each do |group|
+          lines += group.patched_mine
+        end
+        lines.join('')
+      end
+    end
+
+    def diff
+      @diff ||= Diffy::Diff.new(yours, patched_mine).diff
+    end
+
+    protected
+
+    # options pass to diff program
+    def diff_options
+      Array(options[:diff3])
+    end
+
+    # make sure the strings all end with a line break
+    def ensure_line_breaks(*strings)
+      strings.map do |str|
+        str.end_with?("\n") ? str : str + "\n"
+      end
+    end
+  end
+
+
+end

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -641,7 +641,7 @@ describe Diffy::Diff3 do
   let(:code_alt_diff3) {Diffy::Diff3.new(older, yours, mine2)}
 
   it 'should have correct default options' do
-    basic_diff3.options[:diff3].should == '-m'
+    basic_diff3.options[:diff3].should == ["-m", "-L older", "-L mine", "-L yours"]
     basic_diff3.options[:diff].should == '-U 10000'
   end
 

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -536,6 +536,175 @@ baz
   end
 end
 
+
+describe Diffy::Diff3 do
+
+  older = <<-TXT
+    class Bounds
+      def initialize
+      end
+
+      def top
+      end
+
+      def left
+      end
+
+      def width
+      end
+
+      def set
+      end
+    end
+  TXT
+
+  yours = <<-TXT
+    class Bounds
+      def initialize
+        @top = 0
+        @left = 0
+        @width = 0
+      end
+
+      def top
+      end
+
+      def left
+      end
+
+      def width
+      end
+
+      def set(top, left, width)
+        @top = top
+        @left = left
+        @width = width
+      end
+    end
+  TXT
+
+  mine = <<-TXT
+    class Bounds
+      def initialize
+      end
+
+      def top
+        @top ||= 0
+      end
+
+      def left
+        @left ||= 0
+      end
+
+      def width
+        @width ||= 0
+      end
+
+      def set
+      end
+
+      def height
+        @height ||= 0
+      end
+
+    end
+  TXT
+
+  mine2 = <<-TXT
+    class Bounds
+      def initialize
+      end
+
+      def top
+        @top ||= 0
+      end
+
+      def left
+        @left ||= 0
+      end
+
+      def width
+        @width ||= 0
+      end
+
+      def set
+      end
+
+      def height
+        @height ||= 0
+      end
+    end
+  TXT
+
+  let(:basic_diff3) {Diffy::Diff3.new("foo\nbar\npar\ncar", "foo\nbars\npar\ncar\n", "foo\nbar\npars\ncars\n" )}
+  let(:code_diff3) {Diffy::Diff3.new(older, yours, mine)}
+  let(:code_alt_diff3) {Diffy::Diff3.new(older, yours, mine2)}
+
+  it 'should have correct default options' do
+    basic_diff3.options[:diff3].should == '-m'
+    basic_diff3.options[:diff].should == '-U 10000'
+  end
+
+  it 'should return diff content' do
+    basic_diff3.diff3.should_not be_nil
+    basic_diff3.diff3.should_not == ""
+    basic_diff3.diff3.include?("<<<<<<<").should be_true
+    puts code_diff3.diff3
+  end
+
+  it 'should return valid change_groups' do
+    basic_diff3.change_groups.count.should == 2
+    basic_diff3.change_groups.first.conflicts?.should be_false
+    basic_diff3.change_groups.last.conflicts?.should be_true
+    basic_diff3.change_groups.last.mine.any?.should be_true
+    basic_diff3.change_groups.last.yours.any?.should be_true
+  end
+
+  it 'should support three_way_conflicts?' do
+    basic_diff3.three_way_conflicts?.should be_true
+    code_diff3.three_way_conflicts?.should be_false
+  end
+
+  it 'should support patched_mine' do
+    code_diff3.patched_mine.should == <<-TXT
+    class Bounds
+      def initialize
+        @top = 0
+        @left = 0
+        @width = 0
+      end
+
+      def top
+        @top ||= 0
+      end
+
+      def left
+        @left ||= 0
+      end
+
+      def width
+        @width ||= 0
+      end
+
+      def set(top, left, width)
+        @top = top
+        @left = left
+        @width = width
+      end
+
+      def height
+        @height ||= 0
+      end
+
+    end
+    TXT
+  end
+
+  it 'should support to_s' do
+    basic_diff3.to_s.should == " foo\n bars\n-par\n-car\n+pars\n+cars\n"
+  end
+end
+
 describe 'Diffy::CSS' do
   it "should be some css" do
     Diffy::CSS.should include 'diff{overflow:auto;}'


### PR DESCRIPTION
This pull request contains some initial support for using the diff3 unix command. It is designed to work in combination with the existing Diff::Diff object. When a change has been made to a file using an older copy, the newer copy can now have any non-conflicting changes merged into the 2nd string (string2) so that it may be diffed more seamlessly. This allows you to create a 2 file diff out of 3 files. 

API is as follows:

``` ruby

diff3 = Diffy::Diff3.new(oldest, yours, mine)
diff3.diff3 # => returns the output from calling diff3
diff3.patched_mine # => returns a patched version of "mine" that will be used as string2
diff3.to_s # => same as if you were to call on the normal diff object, except now it uses the patched version of string2
diff3.change_groups # => returns an array of groups that is a better data representation of the merged output returned from calling the diff3 utility. 
```

The specs could be beefed up some more, but there is an existing set to get things started. 
