### PR TITLE
Don't use DIV tag for empty diff in HTML format

### DIFF
--- a/lib/diffy/html_formatter.rb
+++ b/lib/diffy/html_formatter.rb
@@ -41,7 +41,7 @@ module Diffy
 
     def wrap_lines(lines)
       if lines.empty?
-        %'<div class="diff"/>'
+        %'<div class="diff"></div>'
       else
         %'<div class="diff">\n  <ul>\n#{lines.join("\n")}\n  </ul>\n</div>\n'
       end


### PR DESCRIPTION
With the [controversy and confusion](http://stackoverflow.com/questions/3558119/are-self-closing-tags-valid-in-html5) surrounding self-closing tags in HTML5, I think it's better not to leave this up to chance. In Chrome OS X 33.0.1750.117, the self-closing DIV tag generated for an empty diff renders as if the div never gets closed. It works fine in Safari 7.0.1 and Firefox 27.0.1, but it is still inconsistent.

According to the [HTML5 Specification](http://dev.w3.org/html5/spec-author-view/syntax.html#syntax-start-tag), a self-closing "normal tag" (such as DIV) is invalid. The specification for a start tag states:

> Then, if the element is one of the void elements, or if the element is a foreign element, then there may be a single U+002F SOLIDUS character (/). This character has no effect on void elements, but on foreign elements it marks the start tag as self-closing.

For "normal" elements (DIV), this specification would fail with the current behavior.

Thanks!
