### PR TITLE
Convert specs to RSpec 2.14.7 syntax with Transpec

### DIFF
--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -20,7 +20,7 @@ describe Diffy::Diff do
       string1 = "foo\nbar\nbang\n"
       string2 = "foo\nbang\n"
       path1, path2 = tempfile(string1), tempfile(string2)
-      Diffy::Diff.new(path1, path2, :source => 'files').to_s.should == <<-DIFF
+      expect(Diffy::Diff.new(path1, path2, :source => 'files').to_s).to eq <<-DIFF
  foo
 -bar
  bang
@@ -31,7 +31,7 @@ describe Diffy::Diff do
       string1 = "foo\nbar\nbang\n"
       string2 = "foo\nbang\n"
       path1, path2 = tempfile(string1, 'path with spaces'), tempfile(string2, 'path with spaces')
-      Diffy::Diff.new(path1, path2, :source => 'files').to_s.should == <<-DIFF
+      expect(Diffy::Diff.new(path1, path2, :source => 'files').to_s).to eq <<-DIFF
  foo
 -bar
  bang
@@ -46,7 +46,7 @@ describe Diffy::Diff do
         string1 = "foo\nbar\nbang\n"
         string2 = "foo\nbang\n"
         path1, path2 = tempfile(string1, 'path with spaces'), tempfile(string2, 'path with spaces')
-        Diffy::Diff.new(path1, path2, :source => 'files').to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(path1, path2, :source => 'files').to_s).to eq <<-DIFF
  foo
 -bar
  bang
@@ -65,8 +65,8 @@ describe Diffy::Diff do
       end
 
       it "should show everything" do
-        Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => false).
-          to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => false).
+          to_s).to eq <<-DIFF
  foo
  bar
  bang
@@ -74,7 +74,7 @@ describe Diffy::Diff do
       end
 
       it "should not show everything if the :allow_empty_diff option is set" do
-        Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => true).to_s.should == ''
+        expect(Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => true).to_s).to eq('')
       end
     end
     describe "with lines that start with backslashes" do
@@ -85,7 +85,7 @@ describe Diffy::Diff do
       end
 
       it "should not leave lines out" do
-        Diffy::Diff.new(@path1, @path2, :source => 'files').to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(@path1, @path2, :source => 'files').to_s).to eq <<-DIFF
  foo
 -\\\\bag
 +\\\\bar
@@ -106,7 +106,7 @@ describe Diffy::Diff do
 +Bar ICS95095010000000000083320000BS01030000004100+\xFF00000000000000000
          DIFF
          desired.force_encoding("ASCII-8BIT") if desired.respond_to?(:force_encoding)
-         Diffy::Diff.new(@path1, @path2, :source => 'files').to_s.should == desired
+         expect(Diffy::Diff.new(@path1, @path2, :source => 'files').to_s).to eq(desired)
        end
      end
 
@@ -117,20 +117,20 @@ describe Diffy::Diff do
       before_tmpfiles = Dir.entries(Dir.tmpdir)
       d = ::Diffy::Diff.new("a", "b").to_s
       after_tmpfiles = Dir.entries(Dir.tmpdir)
-      before_tmpfiles.should =~ after_tmpfiles
+      expect(before_tmpfiles).to match_array(after_tmpfiles)
     end
 
     it "should still be able to generate multiple diffs" do
       d = ::Diffy::Diff.new("a", "b")
-      d.to_s.should be_a String
-      d.to_s(:html).should be_a String
+      expect(d.to_s).to be_a String
+      expect(d.to_s(:html)).to be_a String
     end
   end
 
   describe "options[:context]" do
     it "should limit context lines to 1" do
       diff = Diffy::Diff.new("foo\nfoo\nBAR\nbang\nbaz", "foo\nfoo\nbar\nbang\nbaz", :context => 1)
-      diff.to_s.should == <<-DIFF
+      expect(diff.to_s).to eq <<-DIFF
  foo
 -BAR
 +bar
@@ -142,19 +142,19 @@ describe Diffy::Diff do
   describe "options[:include_plus_and_minus_in_html]" do
     it "defaults to false" do
       @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n")
-      @diffy.options[:include_plus_and_minus_in_html].should == false
+      expect(@diffy.options[:include_plus_and_minus_in_html]).to eq(false)
     end
 
     it "can be set to true" do
       @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :include_plus_and_minus_in_html=> true )
-      @diffy.options[:include_plus_and_minus_in_html].should == true
+      expect(@diffy.options[:include_plus_and_minus_in_html]).to eq(true)
     end
 
     describe "formats" do
       it "includes symbols in html_simple" do
         output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :include_plus_and_minus_in_html => true ).
           to_s(:html_simple)
-        output.should == <<-HTML
+        expect(output).to eq <<-HTML
 <div class="diff">
   <ul>
     <li class="unchanged"><span><span class="symbol"> </span>foo</span></li>
@@ -168,7 +168,7 @@ describe Diffy::Diff do
       it "includes symbols in html" do
         output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\naba\nbang\n", :include_plus_and_minus_in_html => true ).
           to_s(:html)
-        output.should == <<-HTML
+        expect(output).to eq <<-HTML
 <div class="diff">
   <ul>
     <li class="unchanged"><span><span class="symbol"> </span>foo</span></li>
@@ -187,34 +187,34 @@ describe Diffy::Diff do
   describe "options[:include_diff_info]" do
     it "defaults to false" do
       @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n")
-      @diffy.options[:include_diff_info].should == false
+      expect(@diffy.options[:include_diff_info]).to eq(false)
     end
 
     it "can be set to true" do
       @diffy = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :include_diff_info => true )
-      @diffy.options[:include_diff_info].should == true
+      expect(@diffy.options[:include_diff_info]).to eq(true)
     end
 
     it "includes all diff output" do
       output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :include_diff_info => true ).to_s
-      output.to_s.should match( /@@/)
-      output.should match( /---/)
-      output.should match( /\+\+\+/)
+      expect(output.to_s).to match( /@@/)
+      expect(output).to match( /---/)
+      expect(output).to match( /\+\+\+/)
     end
 
     describe "formats" do
       it "works for :color" do
         output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :include_diff_info => true ).to_s(:color)
-        output.should match( /\e\[0m\n\e\[36m\@\@/ )
-        output.to_s.should match( /\e\[90m---/)
-        output.to_s.should match( /\e\[0m\n\e\[90m\+\+\+/)
+        expect(output).to match( /\e\[0m\n\e\[36m\@\@/ )
+        expect(output.to_s).to match( /\e\[90m---/)
+        expect(output.to_s).to match( /\e\[0m\n\e\[90m\+\+\+/)
       end
 
       it "works for :html_simple" do
         output = Diffy::Diff.new("foo\nbar\nbang\n", "foo\nbang\n", :include_diff_info => true ).to_s(:html_simple)
-        output.split("\n").should include( "    <li class=\"diff-block-info\"><span>@@ -1,3 +1,2 @@</span></li>" )
-        output.should include( "<li class=\"diff-comment\"><span>---")
-        output.should include( "<li class=\"diff-comment\"><span>+++")
+        expect(output.split("\n")).to include( "    <li class=\"diff-block-info\"><span>@@ -1,3 +1,2 @@</span></li>" )
+        expect(output).to include( "<li class=\"diff-comment\"><span>---")
+        expect(output).to include( "<li class=\"diff-comment\"><span>+++")
       end
     end
   end
@@ -222,7 +222,7 @@ describe Diffy::Diff do
   describe "options[:diff]" do
     it "should accept an option to diff" do
       @diff = Diffy::Diff.new(" foo\nbar\n", "foo\nbar\n", :diff => "-w", :allow_empty_diff => false)
-      @diff.to_s.should == <<-DIFF
+      expect(@diff.to_s).to eq <<-DIFF
   foo
  bar
       DIFF
@@ -230,7 +230,7 @@ describe Diffy::Diff do
 
     it "should accept multiple arguments to diff" do
       @diff = Diffy::Diff.new(" foo\nbar\n", "foo\nbaz\n", :diff => ["-w", "-U 3"])
-      @diff.to_s.should == <<-DIFF
+      expect(@diff.to_s).to eq <<-DIFF
   foo
 -bar
 +baz
@@ -246,7 +246,7 @@ describe Diffy::Diff do
       end
 
       it "should show everything" do
-        Diffy::Diff.new(@string1, @string2, :allow_empty_diff => false).to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(@string1, @string2, :allow_empty_diff => false).to_s).to eq <<-DIFF
  foo
  bar
  bang
@@ -260,7 +260,7 @@ describe Diffy::Diff do
       end
 
       it "should show one line removed" do
-        Diffy::Diff.new(@string1, @string2).to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(@string1, @string2).to_s).to eq <<-DIFF
  foo
 -bar
  bang
@@ -268,29 +268,29 @@ describe Diffy::Diff do
       end
 
       it "to_s should accept a format key" do
-        Diffy::Diff.new(@string1, @string2).to_s(:color).
-          should == " foo\n\e[31m-bar\e[0m\n bang\n"
+        expect(Diffy::Diff.new(@string1, @string2).to_s(:color)).
+          to eq(" foo\n\e[31m-bar\e[0m\n bang\n")
       end
 
       it "should accept a default format option" do
         old_format = Diffy::Diff.default_format
         Diffy::Diff.default_format = :color
-        Diffy::Diff.new(@string1, @string2).to_s.
-          should == " foo\n\e[31m-bar\e[0m\n bang\n"
+        expect(Diffy::Diff.new(@string1, @string2).to_s).
+          to eq(" foo\n\e[31m-bar\e[0m\n bang\n")
         Diffy::Diff.default_format = old_format
       end
 
       it "should accept a default options" do
         old_options = Diffy::Diff.default_options
         Diffy::Diff.default_options = old_options.merge(:include_diff_info => true)
-        Diffy::Diff.new(@string1, @string2).to_s.
-          should include('@@ -1,3 +1,2 @@')
+        expect(Diffy::Diff.new(@string1, @string2).to_s).
+          to include('@@ -1,3 +1,2 @@')
         Diffy::Diff.default_options = old_options
       end
 
       it "should show one line added" do
-        Diffy::Diff.new(@string2, @string1).to_s.
-          should == <<-DIFF
+        expect(Diffy::Diff.new(@string2, @string1).to_s).
+          to eq <<-DIFF
  foo
 +bar
  bang
@@ -304,7 +304,7 @@ describe Diffy::Diff do
         @string2 = "foo\nbong\nbang\n"
       end
       it "should show one line added and one removed" do
-        Diffy::Diff.new(@string1, @string2).to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(@string1, @string2).to_s).to eq <<-DIFF
  foo
 -bar
 +bong
@@ -319,7 +319,7 @@ describe Diffy::Diff do
         @string2 = "one\ntwo\nthree\n"
       end
       it "should show one line added and one removed" do
-        Diffy::Diff.new(@string1, @string2).to_s.should == <<-DIFF
+        expect(Diffy::Diff.new(@string1, @string2).to_s).to eq <<-DIFF
 -foo
 -bar
 -bang
@@ -337,7 +337,7 @@ describe Diffy::Diff do
         @diff = Diffy::Diff.new(@string1, @string2)
       end
       it "should show one line added and one removed" do
-        @diff.to_s.should == <<-DIFF
+        expect(@diff.to_s).to eq <<-DIFF
 -foo
 +one
 +two
@@ -350,7 +350,7 @@ describe Diffy::Diff do
       end
 
       it "should make an awesome simple html diff" do
-        @diff.to_s(:html_simple).should == <<-HTML
+        expect(@diff.to_s(:html_simple)).to eq <<-HTML
 <div class="diff">
   <ul>
     <li class="del"><del>foo</del></li>
@@ -368,7 +368,7 @@ describe Diffy::Diff do
 
       it "should accept overrides to diff's options" do
         @diff = Diffy::Diff.new(@string1, @string2, :diff => "--rcs")
-        @diff.to_s.should == <<-DIFF
+        expect(@diff.to_s).to eq <<-DIFF
 d1 1
 a1 3
 one
@@ -398,7 +398,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       it "should highlight the changes within the line" do
@@ -416,7 +416,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       it "should not duplicate some lines" do
@@ -433,7 +433,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       it "should escape html" do
@@ -450,7 +450,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       it "should not double escape html in wierd edge cases" do
@@ -465,7 +465,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       it "should highlight the changes within the line with windows style line breaks" do
@@ -483,7 +483,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       it "should treat unix vs windows newlines as differences" do
@@ -500,7 +500,7 @@ baz
   </ul>
 </div>
         HTML
-        @diff.to_s(:html).should ==  html
+        expect(@diff.to_s(:html)).to eq(html)
       end
 
       describe 'with lines that include \n' do
@@ -512,7 +512,7 @@ baz
         end
 
         it "should not leave lines out" do
-          Diffy::Diff.new(@string1, @string2 ).to_s(:html).should == <<-DIFF
+          expect(Diffy::Diff.new(@string1, @string2 ).to_s(:html)).to eq <<-DIFF
 <div class="diff">
   <ul>
     <li class="del"><del>a<strong>\\n</strong>b</del></li>
@@ -526,7 +526,7 @@ baz
       it "should do highlighting on the last line when there's no trailing newlines" do
         s1 = "foo\nbar\nbang"
         s2 = "foo\nbar\nbangleize"
-        Diffy::Diff.new(s1,s2).to_s(:html).should == <<-DIFF
+        expect(Diffy::Diff.new(s1,s2).to_s(:html)).to eq <<-DIFF
 <div class="diff">
   <ul>
     <li class="unchanged"><span>foo</span></li>
@@ -541,36 +541,36 @@ baz
 
     it "should escape diffed html in html output" do
       diff = Diffy::Diff.new("<script>alert('bar')</script>", "<script>alert('foo')</script>").to_s(:html)
-      diff.should include('&lt;script&gt;')
-      diff.should_not include('<script>')
+      expect(diff).to include('&lt;script&gt;')
+      expect(diff).not_to include('<script>')
     end
 
     it "should be easy to generate custom format" do
-      Diffy::Diff.new("foo\nbar\n", "foo\nbar\nbaz\n").map do |line|
+      expect(Diffy::Diff.new("foo\nbar\n", "foo\nbar\nbaz\n").map do |line|
         case line
         when /^\+/ then "line #{line.chomp} added"
         when /^-/ then "line #{line.chomp} removed"
         end
-      end.compact.join.should == "line +baz added"
+      end.compact.join).to eq("line +baz added")
     end
 
     it "should let you iterate over chunks instead of lines" do
-      Diffy::Diff.new("foo\nbar\n", "foo\nbar\nbaz\n").each_chunk.map do |chunk|
+      expect(Diffy::Diff.new("foo\nbar\n", "foo\nbar\nbaz\n").each_chunk.map do |chunk|
         chunk
-      end.should == [" foo\n bar\n", "+baz\n"]
+      end).to eq([" foo\n bar\n", "+baz\n"])
     end
 
     it "should allow chaining enumerable methods" do
-      Diffy::Diff.new("foo\nbar\n", "foo\nbar\nbaz\n").each.map do |line|
+      expect(Diffy::Diff.new("foo\nbar\n", "foo\nbar\nbaz\n").each.map do |line|
         line
-      end.should == [" foo\n", " bar\n", "+baz\n"]
+      end).to eq([" foo\n", " bar\n", "+baz\n"])
     end
   end
 end
 
 describe 'Diffy::CSS' do
   it "should be some css" do
-    Diffy::CSS.should include 'diff{overflow:auto;}'
+    expect(Diffy::CSS).to include 'diff{overflow:auto;}'
   end
 end
 


### PR DESCRIPTION
This conversion is done by Transpec 1.11.1 with the following command:
    transpec
- 53 conversions
  from: obj.should
    to: expect(obj).to
- 38 conversions
  from: == expected
    to: eq(expected)
- 1 conversion
  from: =~ [1, 2]
    to: match_array([1, 2])
- 1 conversion
  from: obj.should_not
    to: expect(obj).not_to
