### PR TITLE
Colorblind-safe pallete available

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ There's some pretty nice css provided in `Diffy::CSS`.
     .diff li.diff-comment { display: none; }
     .diff li.diff-block-info { background: none repeat scroll 0 0 gray; }
 
+
+There's also a colorblind-safe version of the pallete provided in `Diffy::CSS_COLORBLIND_1`.
+
+
 Other Diff Options
 ------------------
 

--- a/lib/diffy/css.rb
+++ b/lib/diffy/css.rb
@@ -14,4 +14,21 @@ module Diffy
 .diff li.diff-comment { display: none; }
 .diff li.diff-block-info { background: none repeat scroll 0 0 gray; }
   STYLE
+
+  CSS_COLORBLIND_1 = <<-STYLE
+.diff{overflow:auto;}
+.diff ul{background:#fff;overflow:auto;font-size:13px;list-style:none;margin:0;padding:0;display:table;width:100%;}
+.diff del, .diff ins{display:block;text-decoration:none;}
+.diff li{padding:0; display:table-row;margin: 0;height:1em;}
+.diff li.ins{background:#ddf; color:#008}
+.diff li.del{background:#fee; color:#b00}
+.diff li:hover{background:#ffc}
+/* try 'whitespace:pre;' if you don't want lines to wrap */
+.diff del, .diff ins, .diff span{white-space:pre-wrap;font-family:courier;}
+.diff del strong{font-weight:normal;background:#fcc;}
+.diff ins strong{font-weight:normal;background:#99f;}
+.diff li.diff-comment { display: none; }
+.diff li.diff-block-info { background: none repeat scroll 0 0 gray; }
+  STYLE
+
 end


### PR DESCRIPTION
There's a new CSS, where greenish colors are replaced by blue-ish colors. This makes a lot easier to see diffy for colorblind people.