### PR TITLE
Add support for side-by-side comparisons (split view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,77 @@ There's some pretty nice css provided in `Diffy::CSS`.
 There's also a colorblind-safe version of the pallete provided in `Diffy::CSS_COLORBLIND_1`.
 
 
+Side-by-side comparisons
+------------------------
+
+Side-by-side comparisons, or split views as called by some, are supported by
+using the `Diffy::SplitDiff` class.  This class takes a diff returned from
+`Diffy::Diff` and splits it in two parts (or two sides): left and right.  The
+left side represents deletions while the right side represents insertions.
+
+The class is used as follows:
+
+```
+Diffy::SplitDiff.new(string1, string2, options = {})
+```
+
+The optional options hash is passed along to the main `Diff::Diff` class, so
+all default options such as full diff output are supported.  The output format
+may be changed by passing the format with the options hash (see below), and all
+default formats are supported.
+
+Unlinke `Diffy::Diff`, `Diffy::SplitDiff` does not use `#to_s` to output
+the resulting diff.  Instead, two self-explanatory methods are used to output
+the diff; `#left` and `#right`.  Using the earlier example, this is what they
+look like in action:
+
+```
+>> puts Diffy::SplitDiff.new(string1, string2).left
+-Hello how are you
+ I'm fine
+-That's great
+```
+
+```
+>> puts Diffy::SplitDiff.new(string1, string2).right
++Hello how are you?
+ I'm fine
++That's swell
+```
+
+### Changing the split view output format
+
+The output format may be changed by passing the format with the options hash:
+
+```
+Diffy::SplitDiff.new(string1, string2, { format: :html }
+```
+
+This will result in the following:
+
+```
+>> puts Diffy::SplitDiff.new(string1, string2, { format: :html }).left
+<div class="diff">
+  <ul>
+    <li class="del"><del>Hello how are you</del></li>
+    <li class="unchanged"><span>I&#39;m fine</span></li>
+    <li class="del"><del>That&#39;s <strong>great</strong></del></li>
+  </ul>
+</div>
+```
+
+```
+>> puts Diffy::SplitDiff.new(string1, string2, { format: :html }).right
+<div class="diff">
+  <ul>
+    <li class="ins"><ins>Hello how are you<strong>?</strong></ins></li>
+    <li class="unchanged"><span>I&#39;m fine</span></li>
+    <li class="ins"><ins>That&#39;s <strong>swell</strong></ins></li>
+  </ul>
+</div>
+```
+
+
 Other Diff Options
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -173,13 +173,13 @@ look like in action:
 The output format may be changed by passing the format with the options hash:
 
 ```
-Diffy::SplitDiff.new(string1, string2, { format: :html }
+Diffy::SplitDiff.new(string1, string2, :format => :html)
 ```
 
 This will result in the following:
 
 ```
->> puts Diffy::SplitDiff.new(string1, string2, { format: :html }).left
+>> puts Diffy::SplitDiff.new(string1, string2, :format => :html).left
 <div class="diff">
   <ul>
     <li class="del"><del>Hello how are you</del></li>
@@ -190,7 +190,7 @@ This will result in the following:
 ```
 
 ```
->> puts Diffy::SplitDiff.new(string1, string2, { format: :html }).right
+>> puts Diffy::SplitDiff.new(string1, string2, :format => :html).right
 <div class="diff">
   <ul>
     <li class="ins"><ins>Hello how are you<strong>?</strong></ins></li>

--- a/lib/diffy.rb
+++ b/lib/diffy.rb
@@ -9,4 +9,5 @@ require 'open3' unless Diffy::WINDOWS
 require File.join(File.dirname(__FILE__), 'diffy', 'format')
 require File.join(File.dirname(__FILE__), 'diffy', 'html_formatter')
 require File.join(File.dirname(__FILE__), 'diffy', 'diff')
+require File.join(File.dirname(__FILE__), 'diffy', 'split_diff')
 require File.join(File.dirname(__FILE__), 'diffy', 'css')

--- a/lib/diffy/split_diff.rb
+++ b/lib/diffy/split_diff.rb
@@ -3,7 +3,8 @@ module Diffy
     def initialize(left, right, options = {})
       @format = options[:format] || Diffy::Diff.default_format
 
-      unless Format.instance_methods.include?(@format)
+      formats = Format.instance_methods(false).map { |x| x.to_s }
+      unless formats.include?(@format.to_s)
         fail ArgumentError, "Format #{format.inspect} is not a valid format"
       end
 

--- a/lib/diffy/split_diff.rb
+++ b/lib/diffy/split_diff.rb
@@ -1,0 +1,48 @@
+module Diffy
+  class SplitDiff
+    def initialize(left, right, options = {})
+      @format = options[:format] || Diffy::Diff.default_format
+
+      unless Format.instance_methods.include?(@format)
+        fail ArgumentError, "Format #{format.inspect} is not a valid format"
+      end
+
+      @diff = Diffy::Diff.new(left, right, options).to_s(@format)
+      @left_diff, @right_diff = split
+    end
+
+    %w(left right).each do |direction|
+      define_method direction do
+        instance_variable_get("@#{direction}_diff")
+      end
+    end
+
+    private
+
+    def split
+      [split_left, split_right]
+    end
+
+    def split_left
+      case @format
+      when :color
+        @diff.gsub(/\033\[32m\+(.*)\033\[0m\n/, '')
+      when :html, :html_simple
+        @diff.gsub(%r{\s+<li class="ins"><ins>(.*)</ins></li>}, '')
+      when :text
+        @diff.gsub(/^\+(.*)\n/, '')
+      end
+    end
+
+    def split_right
+      case @format
+      when :color
+        @diff.gsub(/\033\[31m\-(.*)\033\[0m\n/, '')
+      when :html, :html_simple
+        @diff.gsub(%r{\s+<li class="del"><del>(.*)</del></li>}, '')
+      when :text
+        @diff.gsub(/^-(.*)\n/, '')
+      end
+    end
+  end
+end

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -588,6 +588,73 @@ baz
   end
 end
 
+describe Diffy::SplitDiff do
+  before do
+    ::Diffy::Diff.default_options.merge!(diff: '-U 10000')
+  end
+
+  it "should fail with invalid format" do
+    expected_fail = expect do
+      Diffy::SplitDiff.new("lorem\n", "ipsum\n", { format: :fail })
+    end
+    expected_fail.to raise_error(ArgumentError)
+  end
+
+  describe "#left" do
+    it "should only highlight deletions" do
+      string1 = "lorem\nipsum\ndolor\nsit amet\n"
+      string2 = "lorem\nipsumdolor\nsit amet\n"
+      expect(Diffy::SplitDiff.new(string1, string2).left).to eq <<-TEXT
+ lorem
+-ipsum
+-dolor
+ sit amet
+      TEXT
+    end
+
+    it "should also format left diff as html" do
+      string1 = "lorem\nipsum\ndolor\nsit amet\n"
+      string2 = "lorem\nipsumdolor\nsit amet\n"
+      expect(Diffy::SplitDiff.new(string1, string2, { format: :html}).left).to eq <<-HTML
+<div class="diff">
+  <ul>
+    <li class="unchanged"><span>lorem</span></li>
+    <li class="del"><del>ipsum<strong></strong></del></li>
+    <li class="del"><del><strong></strong>dolor</del></li>
+    <li class="unchanged"><span>sit amet</span></li>
+  </ul>
+</div>
+      HTML
+    end
+  end
+
+  describe "#right" do
+    it "should only highlight insertions" do
+      string1 = "lorem\nipsum\ndolor\nsit amet\n"
+      string2 = "lorem\nipsumdolor\nsit amet\n"
+      expect(Diffy::SplitDiff.new(string1, string2).right).to eq <<-TEXT
+ lorem
++ipsumdolor
+ sit amet
+      TEXT
+    end
+
+    it "should also format right diff as html" do
+      string1 = "lorem\nipsum\ndolor\nsit amet\n"
+      string2 = "lorem\nipsumdolor\nsit amet\n"
+      expect(Diffy::SplitDiff.new(string1, string2, { format: :html}).right).to eq <<-HTML
+<div class="diff">
+  <ul>
+    <li class="unchanged"><span>lorem</span></li>
+    <li class="ins"><ins>ipsumdolor</ins></li>
+    <li class="unchanged"><span>sit amet</span></li>
+  </ul>
+</div>
+      HTML
+    end
+  end
+end
+
 describe 'Diffy::CSS' do
   it "should be some css" do
     expect(Diffy::CSS).to include 'diff{overflow:auto;}'

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -590,12 +590,12 @@ end
 
 describe Diffy::SplitDiff do
   before do
-    ::Diffy::Diff.default_options.merge!(diff: '-U 10000')
+    ::Diffy::Diff.default_options.merge!(:diff => '-U 10000')
   end
 
   it "should fail with invalid format" do
     expected_fail = expect do
-      Diffy::SplitDiff.new("lorem\n", "ipsum\n", { format: :fail })
+      Diffy::SplitDiff.new("lorem\n", "ipsum\n", :format => :fail)
     end
     expected_fail.to raise_error(ArgumentError)
   end
@@ -615,7 +615,7 @@ describe Diffy::SplitDiff do
     it "should also format left diff as html" do
       string1 = "lorem\nipsum\ndolor\nsit amet\n"
       string2 = "lorem\nipsumdolor\nsit amet\n"
-      expect(Diffy::SplitDiff.new(string1, string2, { format: :html}).left).to eq <<-HTML
+      expect(Diffy::SplitDiff.new(string1, string2, :format => :html).left).to eq <<-HTML
 <div class="diff">
   <ul>
     <li class="unchanged"><span>lorem</span></li>
@@ -642,7 +642,7 @@ describe Diffy::SplitDiff do
     it "should also format right diff as html" do
       string1 = "lorem\nipsum\ndolor\nsit amet\n"
       string2 = "lorem\nipsumdolor\nsit amet\n"
-      expect(Diffy::SplitDiff.new(string1, string2, { format: :html}).right).to eq <<-HTML
+      expect(Diffy::SplitDiff.new(string1, string2, :format => :html).right).to eq <<-HTML
 <div class="diff">
   <ul>
     <li class="unchanged"><span>lorem</span></li>


### PR DESCRIPTION
I was inspired to make this by issue #49. I originally made it as an initializer in my Rails project, but after some thought I decided to improve the code and submit a pull request.

This pull request adds support for side-by-side comparisons, or split views, by introducing a new class; `Diffy::SplitDiff`. This class takes a diff returned from `Diffy::Diff` and splits it in two parts (or two sides): left and right. The left side represents deletions while the right side represents insertions.

Unlinke `Diffy::Diff`, `Diffy::SplitDiff` does not use `#to_s` to output the resulting diff. Instead, two self-explanatory methods are used to output the diff; `#left` and `#right`. Using the example from the README, this is what they look like in action:

```
>> puts Diffy::SplitDiff.new(string1, string2).left
-Hello how are you
 I'm fine
-That's great

>> puts Diffy::SplitDiff.new(string1, string2).right
+Hello how are you?
 I'm fine
+That's swell
```

All default formats are supported (more on this in the commit log and the README file).

This commit also adds tests for the new class and its methods, and updates the README with usage information.

Let me know if anything breaks or should have be done differently! :relaxed: