### PR TITLE
Additional information for changed references

### DIFF
--- a/lib/diffy.rb
+++ b/lib/diffy.rb
@@ -8,6 +8,7 @@ end
 require 'open3' unless Diffy::WINDOWS
 require File.join(File.dirname(__FILE__), 'diffy', 'format')
 require File.join(File.dirname(__FILE__), 'diffy', 'html_formatter')
+require File.join(File.dirname(__FILE__), 'diffy', 'html_amplifier')
 require File.join(File.dirname(__FILE__), 'diffy', 'diff')
 require File.join(File.dirname(__FILE__), 'diffy', 'split_diff')
 require File.join(File.dirname(__FILE__), 'diffy', 'css')

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -7,6 +7,7 @@ module Diffy
       :include_plus_and_minus_in_html => false,
       :context => nil,
       :allow_empty_diff => true,
+      :amplify_with => false
     }
 
     class << self

--- a/lib/diffy/html_amplifier.rb
+++ b/lib/diffy/html_amplifier.rb
@@ -1,0 +1,42 @@
+module Diffy
+  class HtmlAmplifier
+
+    REFERENCE_PATTERN = %r{^[+-](\w+)_id}
+    ID_PATTERN = %r{<strong>(\w+)<\/strong>}
+
+    def initialize(html_string, fields = true)
+      @html_string = html_string
+      @fields =
+        if fields == true
+          [:name]
+        elsif fields.is_a?(Array) && !fields.empty?
+          fields
+        end
+    end
+
+    def amplify
+      reference_match = @html_string.match(REFERENCE_PATTERN)
+
+      if reference_match && @fields
+        begin
+          model = reference_match[1].classify.constantize
+          id = @html_string.match(ID_PATTERN)[1].to_i
+          instance = model.find(id)
+
+          @fields.each do |field|
+            if instance.has_attribute?(field)
+              @html_string += ", #{field} = <strong>#{instance.send(field)}" \
+                              '</strong>'
+            end
+          end
+        rescue => error
+          puts 'RESCUE'
+          puts error.to_s
+          @html_string
+        end
+      end
+
+      @html_string
+    end
+  end
+end

--- a/lib/diffy/html_formatter.rb
+++ b/lib/diffy/html_formatter.rb
@@ -77,6 +77,14 @@ module Diffy
                                         )
             hi1 = reconstruct_characters(line_diff, '-')
             hi2 = reconstruct_characters(line_diff, '+')
+
+            amplify_with = @options[:amplify_with]
+            if amplify_with == true ||
+               (amplify_with.is_a?(Array) && !amplify_with.empty?)
+              hi1[0] = Diffy::HtmlAmplifier.new(hi1[0], amplify_with).amplify
+              hi2[0] = Diffy::HtmlAmplifier.new(hi2[0], amplify_with).amplify
+            end
+
             processed << (index + 1)
             [hi1, hi2]
           end


### PR DESCRIPTION
Adds amplifier lib, that shows also assigned fields (:name when `true` passed). Works with changed references, ended by `_id`. For example, in my work project I want to show object name if reference is changed.
PS I know, there are some points that have to be improved. I'll be pleased if anybody review my PR.