### PR TITLE
Fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: ruby
+sudo: false
 rvm:
   - 1.8.7
-  - 1.9.2
-  - 2.0.0
-  - 2.1.0
-  - 2.2.3
+  - 1.9.3-p551
+  - 2.0.0-p648
+  - 2.1.9
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - jruby-9.1.5.0
+  - rbx
+  - rbx-2
+matrix:
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: jruby-9.1.5.0
+    - rvm: rbx
+    - rvm: rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,4 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0'
 end
 
-
-group :test, :development do
-  gemspec
-end
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ require 'rspec/core/rake_task'
 task :default => :spec
 
 desc "Run all specs in spec directory"
+
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
+  t.ruby_opts = "-w"
 end

--- a/diffy.gemspec
+++ b/diffy.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", '~> 2.14'
+  spec.add_development_dependency "rspec"
 end

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -23,7 +23,7 @@ module Diffy
 
     end
     include Enumerable
-    attr_reader :string1, :string2, :options, :diff
+    attr_reader :string1, :string2, :options
 
     # supported options
     # +:diff+::    A cli options string passed to diff

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -12,7 +12,7 @@ module Diffy
     class << self
       attr_writer :default_format
       def default_format
-        @default_format || :text
+        @default_format ||= :text
       end
 
       # default options passed to new Diff objects

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -67,15 +67,17 @@ module Diffy
       end
     ensure
       # unlink the tempfiles explicitly now that the diff is generated
-      Array(@tempfiles).each do |t|
-        begin
-          # check that the path is not nil and file still exists.
-          # REE seems to be very agressive with when it magically removes
-          # tempfiles
-          t.unlink if t.path && File.exist?(t.path)
-        rescue => e
-          warn "#{e.class}: #{e}"
-          warn e.backtrace.join("\n")
+      if defined? @tempfiles # to avoid Ruby warnings about undefined ins var.
+        Array(@tempfiles).each do |t|
+          begin
+            # check that the path is not nil and file still exists.
+            # REE seems to be very agressive with when it magically removes
+            # tempfiles
+            t.unlink if t.path && File.exist?(t.path)
+          rescue => e
+            warn "#{e.class}: #{e}"
+            warn e.backtrace.join("\n")
+          end
         end
       end
     end

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -115,7 +115,7 @@ describe Diffy::Diff do
   describe "handling temp files" do
     it "should unlink tempfiles after generating the diff" do
       before_tmpfiles = Dir.entries(Dir.tmpdir)
-      d = ::Diffy::Diff.new("a", "b").to_s
+      ::Diffy::Diff.new("a", "b").to_s
       after_tmpfiles = Dir.entries(Dir.tmpdir)
       expect(before_tmpfiles).to match_array(after_tmpfiles)
     end


### PR DESCRIPTION
Hi @samg,

I'm working (in a slow pace) to make [Representable](https://github.com/trailblazer/representable) free of warnings.

Some of the warnings popping up from Representable were from *diffy* as it is a Representable's dependency.

So I have opened this PR to make *diffy* free of warnings.

But, the current travis configuration of diffy is failing. So I have made some adjustments at this same PR. I was not able to make 1.8.7 pass on travis. But with theses changes all other version from 1.9 to 2.4 are ok.

cc: @apotonick