### PR TITLE
Travis: Use latest stable JRuby in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
   allow_failures:
     - rvm: 1.8.7
     - rvm: jruby-9.1.8.0
-    - rbx-3.69
+    - rvm: rbx-3.69

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.5.0
+  - jruby-9.1.8.0
   - rbx
   - rbx-2
 matrix:
   allow_failures:
     - rvm: 1.8.7
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-9.1.8.0
     - rvm: rbx
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ rvm:
   - 2.3.3
   - 2.4.0
   - jruby-9.1.8.0
-  - rbx
-  - rbx-2
+  - rbx-3.69
 matrix:
   allow_failures:
     - rvm: 1.8.7
     - rvm: jruby-9.1.8.0
-    - rvm: rbx
-    - rvm: rbx-2
+    - rbx-3.69

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ rvm:
   - 2.3.3
   - 2.4.0
   - jruby-9.1.8.0
-  - rbx-3.69
 matrix:
   allow_failures:
     - rvm: 1.8.7
     - rvm: jruby-9.1.8.0
-    - rvm: rbx-3.69


### PR DESCRIPTION
This PR updates the CI matrix to use latest stable release of JRuby.

---

The Travis Canary build of Rbx require the "sudo trusty" Travis build container, or they won't work. Currently, they don't install in this project's CI setup.
https://travis-ci.org/rubinius/travis-canary/jobs/167918558/config