### PR TITLE
Use posix-spawn instead of Open3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
+dist: xenial
 rvm:
   - 1.8.7
   - 1.9.3-p551

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 cache: bundler
-dist: xenial
 rvm:
   - 1.8.7
   - 1.9.3-p551

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-platforms :ruby do
+platforms :ruby, :jruby do
   gem 'posix-spawn'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-platforms :ruby, :jruby do
+platforms :ruby do
   gem 'posix-spawn'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-platforms :rbx do
-  gem 'rubysl', '~> 2.0'
+platforms :ruby do
+  gem 'posix-spawn'
 end
 
 gemspec

--- a/diffy.gemspec
+++ b/diffy.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", '>= 3.4.4'
 
-  spec.requirements << 'posix-spawn, if not Windows'
+  spec.requirements << 'posix-spawn, if not Windows & Not jruby'
 
-  spec.post_install_message = "Thanks for installing! Please make sure to add posix-spawn as dependency if NON-Windows OS."
+  spec.post_install_message = "Thanks for installing! Please make sure to add posix-spawn as dependency if NON-Windows OS & Not jruby"
 end

--- a/diffy.gemspec
+++ b/diffy.gemspec
@@ -20,4 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+
+  spec.requirements << 'posix-spawn, if not Windows'
+
+  spec.post_install_message = "Thanks for installing! Please make sure to add posix-spawn as dependency if NON-Windows OS."
 end

--- a/lib/diffy.rb
+++ b/lib/diffy.rb
@@ -4,8 +4,15 @@ require 'rbconfig'
 
 module Diffy
   WINDOWS = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+  JRUBY = RUBY_PLATFORM == "java"
 end
-require 'posix/spawn' unless Diffy::WINDOWS
+unless Diffy::WINDOWS
+  if Diffy::JRUBY
+    require 'open3'
+  else
+    require 'posix/spawn'
+  end
+end
 require File.join(File.dirname(__FILE__), 'diffy', 'format')
 require File.join(File.dirname(__FILE__), 'diffy', 'html_formatter')
 require File.join(File.dirname(__FILE__), 'diffy', 'diff')

--- a/lib/diffy.rb
+++ b/lib/diffy.rb
@@ -5,7 +5,7 @@ require 'rbconfig'
 module Diffy
   WINDOWS = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
 end
-require 'open3' unless Diffy::WINDOWS
+require 'posix/spawn' unless Diffy::WINDOWS
 require File.join(File.dirname(__FILE__), 'diffy', 'format')
 require File.join(File.dirname(__FILE__), 'diffy', 'html_formatter')
 require File.join(File.dirname(__FILE__), 'diffy', 'diff')

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -37,7 +37,8 @@ module Diffy
       if ! ['strings', 'files'].include?(@options[:source])
         raise ArgumentError, "Invalid :source option #{@options[:source].inspect}. Supported options are 'strings' and 'files'."
       end
-      @string1, @string2 = string1, string2
+      @string1 = string1.force_encoding('ASCII-8BIT')
+      @string2 = string2.force_encoding('ASCII-8BIT')
     end
 
     def diff

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -50,7 +50,7 @@ module Diffy
           end
 
         if WINDOWS
-          # don't use open3 on windows
+          # don't use posix-spawn on windows
           cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), paths.map { |s| %("#{s}") }.join(' ')
           diff = `#{cmd}`
         else

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -54,7 +54,7 @@ module Diffy
           cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), paths.map { |s| %("#{s}") }.join(' ')
           diff = `#{cmd}`
         else
-          diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
+          diff = POSIX::Spawn::Child.new(diff_bin, *(diff_options + paths)).out
         end
         diff.force_encoding('ASCII-8BIT') if diff.respond_to?(:valid_encoding?) && !diff.valid_encoding?
         if diff =~ /\A\s*\Z/ && !options[:allow_empty_diff]

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -37,8 +37,8 @@ module Diffy
       if ! ['strings', 'files'].include?(@options[:source])
         raise ArgumentError, "Invalid :source option #{@options[:source].inspect}. Supported options are 'strings' and 'files'."
       end
-      @string1 = string1.force_encoding('ASCII-8BIT')
-      @string2 = string2.force_encoding('ASCII-8BIT')
+      @string1 = string1
+      @string2 = string2
     end
 
     def diff
@@ -119,12 +119,12 @@ module Diffy
     end
 
     def tempfile(string)
-      t = Tempfile.new('diffy')
+      t = Tempfile.new('diffy', :encoding => 'ascii-8bit')
       # ensure tempfiles aren't unlinked when GC runs by maintaining a
       # reference to them.
       @tempfiles ||=[]
       @tempfiles.push(t)
-      t.print(string)
+      t.print(string.force_encoding('ASCII-8BIT'))
       t.flush
       t.close
       t.path

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -49,10 +49,13 @@ module Diffy
             [string1, string2]
           end
 
-        if WINDOWS
-          # don't use posix-spawn on windows
+        case
+        when WINDOWS
+          # don't use open3 OR posix-spawn on windows
           cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), paths.map { |s| %("#{s}") }.join(' ')
           diff = `#{cmd}`
+        when JRUBY
+          diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
         else
           diff = POSIX::Spawn::Child.new(diff_bin, *(diff_options + paths)).out
         end

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -37,8 +37,7 @@ module Diffy
       if ! ['strings', 'files'].include?(@options[:source])
         raise ArgumentError, "Invalid :source option #{@options[:source].inspect}. Supported options are 'strings' and 'files'."
       end
-      @string1 = string1
-      @string2 = string2
+      @string1, @string2 = string1, string2
     end
 
     def diff


### PR DESCRIPTION
posix-spawn (https://github.com/rtomayko/posix-spawn)

Use `POSIX::Spawn::Child.new` instead of `Open3.popen3`

See also 

> Q: Why use POSIX::Spawn::Child instead of popen3, hand rolled fork/exec code, or Process::spawn?

https://github.com/rtomayko/posix-spawn/blob/master/lib/posix/spawn/child.rb#L44