### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ A default format can be set like so:
 Installation
 ------------
 
-###on Unix
+### on Unix
 
     gem install diffy
 
-###on Windows:
+### on Windows:
 
 1.  Ensure that you have a working `diff` on your machine and in your search path.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
