### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
 matrix:
   allow_failures:
     - rvm: 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
 matrix:
   allow_failures:
     - rvm: 1.8.7


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html