### PR TITLE
Implemented 'empty?' method for determining whether a diff is empty

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -57,7 +57,8 @@ module Diffy
           diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
         end
         diff.force_encoding('ASCII-8BIT') if diff.respond_to?(:valid_encoding?) && !diff.valid_encoding?
-        if diff =~ /\A\s*\Z/ && !options[:allow_empty_diff]
+        @empty = !!(diff =~ /\A\s*\Z/)
+        if @empty && !options[:allow_empty_diff]
           diff = case options[:source]
           when 'strings' then string1
           when 'files' then File.read(string1)
@@ -138,6 +139,12 @@ module Diffy
           "Format #{format.inspect} not found in #{formats.inspect}"
       end
     end
+
+    def empty?
+      diff unless defined? @diff
+      return @empty
+    end
+
     private
 
     @@bin = nil
@@ -165,6 +172,5 @@ module Diffy
     def diff_options
       Array(options[:context] ? "-U #{options[:context]}" : options[:diff])
     end
-
   end
 end

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -27,6 +27,12 @@ describe Diffy::Diff do
       DIFF
     end
 
+    it "should report different strings as non-empty" do
+      string1 = "foo\nbar\nbaz\n"
+      string2 = "foo\nbar\nbang\n"
+      expect(Diffy::Diff.new(string1, string2).empty?).to eq false
+    end
+
     it "should accept file paths with spaces as arguments" do
       string1 = "foo\nbar\nbang\n"
       string2 = "foo\nbang\n"
@@ -62,6 +68,14 @@ describe Diffy::Diff do
         string1 = "foo\nbar\nbang\n"
         string2 = "foo\nbar\nbang\n"
         @path1, @path2 = tempfile(string1), tempfile(string2)
+      end
+
+      it "should report allow_empty empty diff as empty" do
+        expect(Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => false).empty?).to eq true
+      end
+
+      it "should report a truly empty diff as empty" do
+        expect(Diffy::Diff.new(@path1, @path2, :source => 'files', :allow_empty_diff => true).empty?).to eq true
       end
 
       it "should show everything" do


### PR DESCRIPTION
When using this I thought it would be useful to check if a diff is empty for conditional behaviour.

I'm not hugely happy with the logic in `empty?` - in particular it feels a bit unpleasant to conditionally call `diff,` but it seems like the simplest way of implementing this functionality without some overhaul to break up the `diff` method.

Hope this is useful; let me know if you'd like any changes.