### PR TITLE
Empty @tempfiles variable after diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,4 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 1.8.7
-  - 1.9.3-p551
-  - 2.0.0-p648
-  - 2.1.9
-  - 2.2.6
-  - 2.3.3
   - 2.4.0
-  - jruby-9.1.12.0
-matrix:
-  allow_failures:
-    - rvm: 1.8.7

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Yidffy
+======
+
+This a a forked version of the diffy gem, because we needed a patch to work around a deficiency in the odba gem, which tried to persist closed (temp) files.
+
 Diffy - Easy Diffing With Ruby [![Build Status](https://travis-ci.org/samg/diffy.svg?branch=master)](https://travis-ci.org/samg/diffy)
 ============================
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
 
 task :default => :spec
 

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -79,6 +79,7 @@ module Diffy
             warn e.backtrace.join("\n")
           end
         end
+        @tempfiles = []
       end
     end
 

--- a/lib/diffy/version.rb
+++ b/lib/diffy/version.rb
@@ -1,3 +1,3 @@
 module Diffy
-  VERSION = '3.2.0'
+  VERSION = '0.0.1'
 end

--- a/lib/diffy/version.rb
+++ b/lib/diffy/version.rb
@@ -1,3 +1,3 @@
 module Diffy
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -1,6 +1,9 @@
 require 'rspec'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'diffy'))
 
+class Diffy::Diff
+  attr_reader :tempfiles
+end
 describe Diffy::Diff do
 
   describe "diffing two files" do
@@ -36,6 +39,16 @@ describe Diffy::Diff do
 -bar
  bang
       DIFF
+    end
+
+    it "should have and empty tempfiles variable after calling diff" do
+      string1 = "foo\nbar\nbang\n"
+      string2 = "foo\nbang\n"
+      path1, path2 = tempfile(string1, 'path with spaces'), tempfile(string2, 'path with spaces')
+      res = Diffy::Diff.new(path1, path2, :source => 'strings')
+      expect(res.tempfiles).to eq nil
+      res.diff
+      expect(res.tempfiles).to eq []
     end
 
     it "should accept file paths with spaces as arguments on windows" do

--- a/ydiffy.gemspec
+++ b/ydiffy.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'diffy/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "diffy"
+  spec.name          = "ydiffy"
   spec.version       = Diffy::VERSION
   spec.authors       = ["Sam Goldstein"]
   spec.email         = ["sgrock@gmail.org"]
   spec.description   = "Convenient diffing in ruby"
-  spec.summary       = "A convenient way to diff string in ruby"
-  spec.homepage      = "http://github.com/samg/diffy"
+  spec.summary       = "Ydiffy is a fork of diffy to work around a problem in odba"
+  spec.homepage      = "http://github.com/zdavatz/ydiffy"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Hi
First many thanks for your nice gem.

I am using a not very popular persistenc gem odba.

It has problems marshalling a Diffy::Diff object, when it encounters the (closed) tempfiles.
Emptying the @tempfiles array after the diff fixes this problem for me.

I added also a spec test, which unfortunately breaks for unclear reasons with Ruby: 2.0.0-p648.

Best regards
