### PR TITLE
Fix diff lines that begin with -- or ++

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -42,7 +42,7 @@ module Diffy
 
     def diff
       @diff ||= begin
-        paths = case options[:source]
+        @paths = case options[:source]
           when 'strings'
             [tempfile(string1), tempfile(string2)]
           when 'files'
@@ -51,10 +51,10 @@ module Diffy
 
         if WINDOWS
           # don't use open3 on windows
-          cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), paths.map { |s| %("#{s}") }.join(' ')
+          cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), @paths.map { |s| %("#{s}") }.join(' ')
           diff = `#{cmd}`
         else
-          diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
+          diff = Open3.popen3(diff_bin, *(diff_options + @paths)) { |i, o, e| o.read }
         end
         diff.force_encoding('ASCII-8BIT') if diff.respond_to?(:valid_encoding?) && !diff.valid_encoding?
         if diff =~ /\A\s*\Z/ && !options[:allow_empty_diff]
@@ -84,9 +84,20 @@ module Diffy
 
     def each
       lines = case @options[:include_diff_info]
-      when false then diff.split("\n").reject{|x| x =~ /^(---|\+\+\+|@@|\\\\)/ }.map {|line| line + "\n" }
-      when true then diff.split("\n").map {|line| line + "\n" }
+      when false
+        # this "primes" the diff and sets up the paths we'll reference below.
+        diff
+
+        # caching this regexp improves the performance of the loop by a
+        # considerable amount.
+        regexp = /^(--- "?#{@paths[0]}"?|\+\+\+ "?#{@paths[1]}"?|@@|\\\\)/
+
+        diff.split("\n").reject{|x| x =~ regexp }.map {|line| line + "\n" }
+
+      when true
+        diff.split("\n").map {|line| line + "\n" }
       end
+
       if block_given?
         lines.each{|line| yield line}
       else

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -585,6 +585,30 @@ baz
         line
       end).to eq([" foo\n", " bar\n", "+baz\n"])
     end
+
+    it "should handle lines that begin with --" do
+      string1 = "a a\n-- b\nc c\n"
+      string2 = "a a\nb b\nc c\n"
+
+      expect(Diffy::Diff.new(string1, string2).to_s).to eq <<-DIFF
+ a a
+--- b
++b b
+ c c
+      DIFF
+    end
+
+    it "should handle lines that begin with ++" do
+      string1 = "a a\nb b\nc c\n"
+      string2 = "a a\n++ b\nc c\n"
+
+      expect(Diffy::Diff.new(string1, string2).to_s).to eq <<-DIFF
+ a a
+-b b
++++ b
+ c c
+      DIFF
+    end
   end
 end
 


### PR DESCRIPTION
We can leverage the file paths path to enhance our regex, since the odds
of them matching exactly what appears in a diff output are pretty minimal.

Fixes issues #77 and #92.