### PR TITLE
Use posix-spawn instead of forking to reduce memory usage

### DIFF
--- a/diffy.gemspec
+++ b/diffy.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_runtime_dependency "posix-spawn"
 end

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
+require 'posix/spawn'
+
 module Diffy
   class Diff
+    include POSIX::Spawn
+
     ORIGINAL_DEFAULT_OPTIONS = {
       :diff => '-U10000',
       :source => 'strings',
@@ -54,7 +60,9 @@ module Diffy
           cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), paths.map { |s| %("#{s}") }.join(' ')
           diff = `#{cmd}`
         else
-          diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
+          # diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
+          _pid, _i, o, _e = popen4(diff_bin, *(diff_options + paths))
+          diff = o.read
         end
         diff.force_encoding('ASCII-8BIT') if diff.respond_to?(:valid_encoding?) && !diff.valid_encoding?
         if diff =~ /\A\s*\Z/ && !options[:allow_empty_diff]

--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -60,7 +60,6 @@ module Diffy
           cmd = sprintf '"%s" %s %s', diff_bin, diff_options.join(' '), paths.map { |s| %("#{s}") }.join(' ')
           diff = `#{cmd}`
         else
-          # diff = Open3.popen3(diff_bin, *(diff_options + paths)) { |i, o, e| o.read }
           _pid, _i, o, _e = popen4(diff_bin, *(diff_options + paths))
           diff = o.read
         end


### PR DESCRIPTION
Forking creates a new process with the same memory usage as the parent process. Since ruby doesn't give memory back to the operating system, this can cause the calling process to bloat and consume much more memory than is necessary.

By using spawn, the new process consumes far less memory and returns it to the operating system once it has completed. This is very beneficial for long-running processes such as rails app servers.