### PR TITLE
diff_options: Remove space between U and context number

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -174,7 +174,7 @@ module Diffy
 
     # options pass to diff program
     def diff_options
-      Array(options[:context] ? "-U #{options[:context]}" : options[:diff])
+      Array(options[:context] ? "-U#{options[:context]}" : options[:diff])
     end
 
   end


### PR DESCRIPTION
This allows diffy to work with the Busybox diff command, which returns `diff: invalid number ' 1'` in its current form