### PR TITLE
Add option `:ignore_crlf` to fix #105

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ combined with the `:context` option.
       foo
      bar
 
+### `:ignore_crlf` when doing HTML compares
+
+You can make the HTML output ignore the CRLF by passing the `:ignore_crlf` option a truthy value.
+
+    >> puts Diffy::Diff.new(" foo\nbar\n", "foo\r\nbar\r\n", ignore_crlf: true).to_s(:html)
+      "<div class=\"diff\"></div>"
+
+
+
 Default Diff Options
 --------------------
 

--- a/lib/diffy/html_formatter.rb
+++ b/lib/diffy/html_formatter.rb
@@ -90,10 +90,14 @@ module Diffy
 
     def split_characters(chunk)
       chunk.gsub(/^./, '').each_line.map do |line|
-        chars = line.sub(/([\r\n]$)/, '').split('')
-        # add escaped newlines
-        chars << '\n'
-        chars.map{|chr| ERB::Util.h(chr) }
+        if @options[:ignore_crlf]
+          (line.chomp.split('') + ['\n']).map{|chr| ERB::Util.h(chr) }
+        else
+          chars = line.sub(/([\r\n]$)/, '').split('')
+          # add escaped newlines
+          chars << '\n'
+          chars.map{|chr| ERB::Util.h(chr) }
+        end
       end.flatten.join("\n") + "\n"
     end
 

--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -503,6 +503,13 @@ baz
         expect(@diff.to_s(:html)).to eq(html)
       end
 
+      it "should treat unix vs windows newlines as same if option :ignore_crlf" do
+        @diff = Diffy::Diff.new("one\ntwo\nthree\n", "one\r\ntwo\r\nthree\r\n",
+                               ignore_crlf: true)
+        empty_diff = "<div class=\"diff\"></div>"
+        expect(@diff.to_s(:html)).to eq(empty_diff)
+      end
+
       describe 'with lines that include \n' do
         before do
           string1 = 'a\nb'"\n"


### PR DESCRIPTION
The option `ignore_crlf` if passed, will ignore CRLF differences in HTML