### PR TITLE
Fix unused `stderr` variable warning

### DIFF
--- a/lib/diffy/diff.rb
+++ b/lib/diffy/diff.rb
@@ -49,7 +49,7 @@ module Diffy
             [string1, string2]
           end
 
-        diff, stderr, process_status = Open3.capture3(diff_bin, *(diff_options + @paths))
+        diff, _stderr, process_status = Open3.capture3(diff_bin, *(diff_options + @paths))
         diff.force_encoding('ASCII-8BIT') if diff.respond_to?(:valid_encoding?) && !diff.valid_encoding?
         if diff =~ /\A\s*\Z/ && !options[:allow_empty_diff]
           diff = case options[:source]


### PR DESCRIPTION
If used in combination with `ruby -w`, the unused `stderr` variable causes a warning. Prefixing it with an underscore tells Ruby we're doing it intentionally and avoids the warning.