### PR TITLE
Add 3.0.x to the rvm build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
+  - 3.0
   - jruby-9.1.12.0
 matrix:
   allow_failures:


### PR DESCRIPTION
Adds Ruby 3.0.x testing support to the build matrix.

I was able to cleanly run specs against 3.0.2 and 3.0.4 locally, so I 🤞 this would pass cleanly.