### PR TITLE
Use rugged for diffing

### DIFF
--- a/diffy.gemspec
+++ b/diffy.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.0.0"
+
+  spec.add_dependency "rugged", "~> 1.7"
+
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/diffy.rb
+++ b/lib/diffy.rb
@@ -1,11 +1,7 @@
-require 'tempfile'
 require 'erb'
 require 'rbconfig'
+require 'rugged'
 
-module Diffy
-  WINDOWS = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-end
-require 'open3' unless Diffy::WINDOWS
 require File.join(File.dirname(__FILE__), 'diffy', 'format')
 require File.join(File.dirname(__FILE__), 'diffy', 'html_formatter')
 require File.join(File.dirname(__FILE__), 'diffy', 'diff')


### PR DESCRIPTION
This is a proof of concept.

Diffy currently uses a subprocesses to obtain a diff. This instead uses libgit through the gem rugged. I have opted to ignore backwards compatibility for this. There is probably a way you can have the current mode and this coexist but that would have introduced a bunch more complexity (I also don't see why you'd want to maintain both versions anyways).
Almost all tests are passing, except a few outliers I couldn't quite figure out myself.

This version is faster since it doesn't have to spawn subprocesses and is easier to install and deploy because rugged comes with everything it needs out of the box.

Connects to #123

Here is a monkeypatch to make use of this today. It's lacking quite a few features normally found in the gem but it works for my specific usecase and can easily extended.

```rb
require "rugged"

module DiffyNoSubprocess
  def diff
    @diff ||= Rugged::Patch.from_strings(@string1, @string2, context_lines: 10_000).to_s.force_encoding("UTF-8")
  end

  def each
    lines = diff.split("\n").drop(5).map { |line| "#{line}\n" }

    if block_given?
      lines.each { |line| yield line }
    else
      lines.to_enum
    end
  end
end

Diffy::Diff.prepend DiffyNoSubprocess
```