### PR TITLE
Fix HTML diff highlighting bug for lines containing `'\n'`

### DIFF
--- a/spec/diffy_spec.rb
+++ b/spec/diffy_spec.rb
@@ -530,6 +530,24 @@ baz
         end
       end
 
+      describe 'with lines that include \n but not as a diff' do
+        before do
+          @string1 = 'a\nb'"\n"
+          @string2 = 'a\nc'"\n"
+        end
+
+        it "should not leave lines out" do
+          expect(Diffy::Diff.new(@string1, @string2).to_s(:html)).to eq <<-DIFF
+<div class="diff">
+  <ul>
+    <li class="del"><del>a\\n<strong>b</strong></del></li>
+    <li class="ins"><ins>a\\n<strong>c</strong></ins></li>
+  </ul>
+</div>
+          DIFF
+        end
+      end
+
       it "should do highlighting on the last line when there's no trailing newlines" do
         s1 = "foo\nbar\nbang"
         s2 = "foo\nbar\nbangleize"


### PR DESCRIPTION
## Overview

This pull request fixes a bug in HTML diff output where, if a line contains `'\n'` and there are differences in parts of the line other than `'\n'`, the `'\n'` is incorrectly treated as a newline character and causes unintended line breaks.

## Details

- In the implementation of `Diffy::HtmlFormatter`, when comparing lines containing `'\n'`, if there are differences outside of the `'\n'` part, `'\n'` was interpreted as an actual newline in the HTML output, resulting in the line being split.
- This issue only occurs with the `:html` format and does not affect other formats such as `:html_simple`.
- With this fix, the `'\n'` part is displayed as-is in a single line, and only the differing parts are correctly highlighted.
- Additional tests have been added to cover this case.

---

This is my first time submitting a pull request to this project.
I would appreciate your review, and if there is anything else I should do or if you have any feedback, please let me know.